### PR TITLE
Add schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# YAML Database (yamldb)
+# yamldb (YAML Database)
 Simple disk-backed key-value store for YAML files. 
 
 You probably shouldn't use this as your go-to database solution in most cases.
 A realistic use-case for yamldb is when you have a small app that requires a few human-readable configuration files to be stored locally.
 
+## Features
+- [x] CRUD data to disk
+- [x] Reference other YAML files with constraints (think like SQL foreign keys)
+- [x] Ordered keys through sorting, compression and anything else that's made possible with [diskv](https://github.com/peterbourgon/diskv)
+
 ## Usage
-The basics:
+The best way to learn more about this API is to check out the tests: [yamldb](./yamldb_test.go) & [schemas](./schema_test.go).
+
+But here's a very basic 'read-write arbitrary data' example to get you started:
 ```go
 package main
 
@@ -46,5 +53,3 @@ func main() {
 	log.Println(out.Value)
 }
 ```
-
-See [tests](./yamldb_test.go) for more examples.

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,106 @@
+package yamldb
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Action string
+
+const (
+	// Cascade modifies the referenced Schema based on the constraint.
+	Cascade Action = "cascade"
+	// Restrict prevents modifications to the referenced Schema based on the constraint.
+	Restrict Action = "restrict"
+	// NoAction doesn't touch the referenced Schema when any of the constraints are triggered.
+	NoAction Action = "no action"
+)
+
+var (
+	UpdateRestrictedError = errors.New("can't update because there's still a reference to another resource (blocked by constraint)")
+)
+
+type Constraints struct {
+	// Update triggers specified Action when Schema Data is modified.
+	Update Action
+	// Delete triggers specified Action when this Schema gets deleted.
+	Delete Action
+}
+
+type SchemaReference struct {
+	// Key to another YAML file in the database.
+	Key string
+
+	// Constraints trigger Actions that have an effect on the referenced Schema whenever this Schema changes.
+	Constraints Constraints
+}
+
+// Schema represents a versioned YAML data structure that can also reference other files in the database.
+// Think of it like an SQL table.
+type Schema struct {
+	// Version number.
+	// This value should be increased whenever the schema data type changes.
+	// You can then check this number later in your code to perform the appropriate upgrades or migrations.
+	Version int
+
+	// YAML file key as stored in the database.
+	// The value of this key MUST be unique AND equal the file key,
+	// as it will later be used by other Schemas to reference this one.
+	Key string
+
+	// Reference is a link to another Schema.
+	Reference *SchemaReference
+
+	// Inner YAML data to store.
+	Data interface{}
+}
+
+// Delete deletes the schema and file on disk while also triggering any set constraints.
+func (s *Schema) Delete(db *YamlDb) error {
+	if s.Reference != nil && db.Has(s.Reference.Key) {
+		switch s.Reference.Constraints.Delete {
+		case Cascade:
+			if err := db.Delete(s.Reference.Key); err != nil {
+				return err
+			}
+		case Restrict:
+			return fmt.Errorf("can't delete because there's still a reference to another resource (blocked by constraint)")
+		case NoAction:
+		default:
+			break
+		}
+	}
+
+	if db.Has(s.Key) {
+		return db.Delete(s.Key)
+	}
+
+	return nil
+}
+
+// Update changes this and referenced schema key while also triggering any set constraints.
+func (s *Schema) Update(db *YamlDb, updatedKey string, onUpdate func(schema *Schema)) error {
+	if s.Reference != nil {
+		if !db.Has(s.Reference.Key) {
+			return fmt.Errorf("old reference to %s not found", s.Reference.Key)
+		}
+		switch s.Reference.Constraints.Update {
+		case Cascade:
+			// TODO: link back to referenced table somehow (probably gonna need reflection) and actually update the 'foreign key' to the new key
+			fallthrough
+		case Restrict:
+			return UpdateRestrictedError
+		case NoAction:
+		default:
+			break
+		}
+	}
+
+	return db.Update(s.Key, s, func(i interface{}) {
+		schema := i.(*Schema)
+		schema.Key = updatedKey
+		if onUpdate != nil {
+			onUpdate(schema)
+		}
+	})
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,97 @@
+package yamldb
+
+import (
+	"testing"
+)
+
+// One User can have many Posts.
+type User struct {
+	Id   int
+	Name string
+}
+
+// Only one Post can belong to one User.
+type Post struct {
+	Id      int
+	Message string
+}
+
+const (
+	userKey = "users/1"
+	postKey = "posts/1"
+)
+
+func getUserSchema() (Schema, *YamlDb, error) {
+	db := New(&DiskOptions{
+		BasePath:        basePath,
+		AppendExtension: true,
+	})
+
+	// write user schema
+	err := db.Write(userKey, Schema{
+		Key: userKey,
+		Reference: &SchemaReference{
+			Key: postKey, // references the post below
+			Constraints: Constraints{
+				Delete: Cascade,
+				Update: Cascade,
+			},
+		},
+		Data: User{
+			Id:   1,
+			Name: "David",
+		},
+	})
+	if err != nil {
+		return Schema{}, nil, err
+	}
+
+	// write post schema
+	err = db.Write(postKey, Schema{
+		Key: postKey,
+		Data: Post{
+			Id:      1,
+			Message: "Hello World!",
+		},
+	})
+
+	// unserialize user schema
+	var schema Schema
+	if err = db.Read(userKey, &schema); err != nil {
+		return Schema{}, nil, err
+	}
+
+	return schema, db, nil
+}
+
+func TestSchema_Delete(t *testing.T) {
+	schema, db, err := getUserSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.PurgeAll()
+
+	// delete the user
+	if err = schema.Delete(db); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify whether the related post has also been deleted
+	if db.Has(userKey) || db.Has(postKey) {
+		t.FailNow()
+	}
+}
+
+func TestSchema_Update(t *testing.T) {
+	schema, db, err := getUserSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.PurgeAll()
+
+	// update the user schema key
+	// NOTE: in a realistic scenario you would also move the local file to a new location beforehand.
+	if err = schema.Update(db, "users/2", nil); err != nil && err != UpdateRestrictedError {
+		t.Fatal(err)
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -30,11 +30,13 @@ func getUserSchema() (Schema, *YamlDb, error) {
 	// write user schema
 	err := db.Write(userKey, Schema{
 		Key: userKey,
-		Reference: &SchemaReference{
-			Key: postKey, // references the post below
-			Constraints: Constraints{
-				Delete: Cascade,
-				Update: Cascade,
+		References: []*SchemaReference{
+			{
+				Key: postKey, // references the post below
+				Constraints: Constraints{
+					Delete: Cascade,
+					Update: Cascade,
+				},
 			},
 		},
 		Data: User{

--- a/yamldb_test.go
+++ b/yamldb_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 )
 
+const basePath = "./test-data"
+
 func newYamlDb() *YamlDb {
 	return New(&DiskOptions{
-		BasePath:        "test-data",
+		BasePath:        basePath,
 		AppendExtension: true,
 	})
 }
@@ -25,7 +27,7 @@ type Mock struct {
 
 func TestYamlDb_WriteRaw(t *testing.T) {
 	db := New(&DiskOptions{
-		BasePath:        "./test-data",
+		BasePath:        basePath,
 		AppendExtension: false,
 	})
 	defer db.PurgeAll()
@@ -192,7 +194,7 @@ func TestYamlDb_GetOrderedKeys(t *testing.T) {
 	}
 
 	db := New(&DiskOptions{
-		BasePath:        "./test-data",
+		BasePath:        basePath,
 		AppendExtension: false,
 		SortKeys:        true,
 		SortOrderFunc:   OrderAlphabeticallyReversed,
@@ -216,7 +218,7 @@ func TestYamlDb_GetOrderedKeys(t *testing.T) {
 
 func TestYamlDb_GetOrderedKeys2(t *testing.T) {
 	db := New(&DiskOptions{
-		BasePath:        "./test-data",
+		BasePath:        basePath,
 		AppendExtension: false,
 		SortKeys:        true,
 		SortOrderFunc:   OrderAlphabetically,


### PR DESCRIPTION
Reinvented SQL foreign keys for YAML (but references are technically in reverse).

- Added a `Schema` type which, if used by the programmer because it's optional, can store relational references. Output data looks like this:
```yaml
# file stored as <root>/users/1.yaml
#
# schema version
version: 1
# unique key
key: users/1
# relationships
references:
- key: posts/1
  constraints:
    update: cascade
    delete: cascade
# user-defined data
data:
  id: 1
  name: David

```